### PR TITLE
[FIX] Update Services link to navigate to /services

### DIFF
--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -14,7 +14,7 @@
 			<img src="https://placehold.co/100x60" alt="" />
 		</a>
 		<a href="/" class:font-semibold={page.url.pathname === '/'}>Home</a>
-		<a href="#">Services</a>
+		<a href="/services" class:font-semibold={page.url.pathname === '/services'}>Services</a>
 		<a href="#">Track</a>
 		<a href="/faq">FAQs</a>
 	</div>


### PR DESCRIPTION
Changed the Services navigation link to point to the /services route and added active styling when on that page.