### PR TITLE
[FIX] Update product display and actions for staff and sold out status

### DIFF
--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -121,15 +121,20 @@
 	<h2 class="font-spaceGrotesk font-bold text-4xl mb-6">Got some questions?</h2>
 	<a href="#" class="border-2 border-white rounded-4xl px-6 py-2">Read our FAQs</a>
 </div>
-<!-- TODO: add signed in detection -->
-<div class="py-48 flex justify-between px-40">
-	<div>
-		<h2 class="font-spaceGrotesk font-bold text-8xl text-white mb-7">
+<div class="py-52 px-40 flex flex-row items-center justify-between">
+	<div class="flex flex-col justify-center" style="min-width: 480px;">
+		<h2 class="font-spaceGrotesk font-bold text-8xl text-white mb-2">
 			<span class="block textOutline text-transparent">Sign up</span> and save
 		</h2>
-		<p class="text-white font-roboto">Register and Subscribe to get special offers</p>
+		<p class="text-white font-roboto text-lg">Register and Subscribe to get special offers</p>
 	</div>
-	<a href="#" class="bg-amber-300 font-roboto rounded-4xl px-6 py-2 h-min self-center"
-		>Register / Log in</a
-	>
+	<div class="flex items-center">
+		{#if !$user}
+			<a href="/register" class="bg-amber-300 font-roboto rounded-4xl px-8 py-3 text-base">Register / Log in</a>
+		{:else if isStaffUser($user)}
+			<a href="/dashboard" class="bg-amber-300 font-roboto rounded-4xl px-8 py-3 text-base">Go to Dashboard</a>
+		{:else}
+			<a href="/cart" class="bg-amber-300 font-roboto rounded-4xl px-8 py-3 text-base">Go to Cart</a>
+		{/if}
+	</div>
 </div>

--- a/src/routes/(public)/services/+page.svelte
+++ b/src/routes/(public)/services/+page.svelte
@@ -18,37 +18,30 @@
         <div class="grid grid-cols-4 gap-18 py-10">
             <div class="products flex flex-col">
                 <div class="image bg-white flex items-center justify-center">Placeholder</div>
-                        
                 <div class="flex flex-col justify-center items-center py-10">
-                    <p class="products-font-name">Lorem ipsum dolor sit amet</p>
-                    <p class="products-font-price">Lorem ipsum</p>
+                    <p class="font-bold underline text-lg mb-1">Disposable Camera Service</p>
+                    <p class="text-base">from P150</p>
                 </div>
             </div>
-
             <div class="products flex flex-col w-349px">
                 <div class="image bg-white flex items-center justify-center">Placeholder</div>
-                        
                 <div class="flex flex-col justify-center items-center py-10">
-                    <p class="products-font-name">Lorem ipsum dolor sit amet</p>
-                    <p class="products-font-price">Lorem ipsum</p>
-                </div>
-                </div>
-
-            <div class="products flex flex-col w-349px">
-                <div class="image bg-white flex items-center justify-center">Placeholder</div>
-                        
-                <div class="flex flex-col justify-center items-center py-10">
-                    <p class="products-font-name">Lorem ipsum dolor sit amet</p>
-                    <p class="products-font-price">Lorem ipsum</p>
+                    <p class="font-bold underline text-lg mb-1">35mm Services</p>
+                    <p class="text-base">from P150</p>
                 </div>
             </div>
-
             <div class="products flex flex-col w-349px">
                 <div class="image bg-white flex items-center justify-center">Placeholder</div>
-                        
                 <div class="flex flex-col justify-center items-center py-10">
-                    <p class="products-font-name">Lorem ipsum dolor sit amet</p>
-                    <p class="products-font-price">Lorem ipsum</p>
+                    <p class="font-bold underline text-lg mb-1">120 Film Services</p>
+                    <p class="text-base">from P200</p>
+                </div>
+            </div>
+            <div class="products flex flex-col w-349px">
+                <div class="image bg-white flex items-center justify-center">Placeholder</div>
+                <div class="flex flex-col justify-center items-center py-10">
+                    <p class="font-bold underline text-lg mb-1">3R - 8R Printing</p>
+                    <p class="text-base">from P8.00</p>
                 </div>
             </div>
         </div>
@@ -112,9 +105,13 @@
 		</h2>
 		<p class="text-white font-roboto">Register and Subscribe to get special offers</p>
 	</div>
-	<a href="#" class="bg-amber-300 font-roboto rounded-4xl px-6 py-2 h-min self-center"
-		>Register / Log in</a
-	>
+	{#if !$user}
+		<a href="/register" class="bg-amber-300 font-roboto rounded-4xl px-6 py-2 h-min self-center">Register / Log in</a>
+	{:else if isStaffUser($user)}
+		<a href="/dashboard" class="bg-amber-300 font-roboto rounded-4xl px-6 py-2 h-min self-center">Go to Dashboard</a>
+	{:else}
+		<a href="/cart" class="bg-amber-300 font-roboto rounded-4xl px-6 py-2 h-min self-center">Go to Cart</a>
+	{/if}
 </div>
 
 


### PR DESCRIPTION
Refactored product display logic on the home and services pages to show the first three products on the home page, display a 'Sold Out' badge for unavailable products, and disable the 'Add to cart' button for staff users or sold out products. Also updated the 'View all' link to point to the services page and improved conditional rendering for staff users.

more to this in the upcoming days