### PR TITLE
[FIX] Add placeholder comments to select fields in service forms

### DIFF
--- a/src/routes/(public)/services/120mm/+page.svelte
+++ b/src/routes/(public)/services/120mm/+page.svelte
@@ -104,6 +104,7 @@ const handleSubmit = (e: SubmitEvent) => {
                 bind:value={processType}
                 on:change={(e) => handleFieldChange('processType', e.currentTarget.value)}
             >
+                <!-- FIX: placeholder -->
                 <option value="">Select process type</option>
                 <option value="option1">Option 1</option>
                 <option value="option2">Option 2</option>
@@ -127,6 +128,7 @@ const handleSubmit = (e: SubmitEvent) => {
                 bind:value={returningNegatives}
                 on:change={(e) => handleFieldChange('returningNegatives', e.currentTarget.value)}
             >
+                <!-- FIX: placeholder -->
                 <option value="">Select how would you like to get your negatives back</option>
                 <option value="option1">Option 1</option>
                 <option value="option2">Option 2</option>

--- a/src/routes/(public)/services/35mm/+page.svelte
+++ b/src/routes/(public)/services/35mm/+page.svelte
@@ -105,6 +105,7 @@ const handleSubmit = (e: SubmitEvent) => {
                 bind:value={processType}
                 on:change={(e) => handleFieldChange('processType', e.currentTarget.value)}
             >
+                <!-- FIX: placeholder -->
                 <option value="">Select process type</option>
                 <option value="option1">Option 1</option>
                 <option value="option2">Option 2</option>
@@ -128,6 +129,7 @@ const handleSubmit = (e: SubmitEvent) => {
                 bind:value={returningNegatives}
                 on:change={(e) => handleFieldChange('returningNegatives', e.currentTarget.value)}
             >
+                <!-- FIX: placeholder -->
                 <option value="">Select how would you like to get your negatives back</option>
                 <option value="option1">Option 1</option>
                 <option value="option2">Option 2</option>

--- a/src/routes/(public)/services/disposable/+page.svelte
+++ b/src/routes/(public)/services/disposable/+page.svelte
@@ -104,6 +104,7 @@ const handleSubmit = (e: SubmitEvent) => {
                 bind:value={processType}
                 on:change={(e) => handleFieldChange('processType', e.currentTarget.value)}
             >
+                <!-- FIX: placeholder -->
                 <option value="">Select process type</option>
                 <option value="option1">Option 1</option>
                 <option value="option2">Option 2</option>
@@ -127,6 +128,7 @@ const handleSubmit = (e: SubmitEvent) => {
                 bind:value={returningNegatives}
                 on:change={(e) => handleFieldChange('returningNegatives', e.currentTarget.value)}
             >
+                <!-- FIX: placeholder -->
                 <option value="">Select how to return negatives</option>
                 <option value="option1">Option 1</option>
                 <option value="option2">Option 2</option>


### PR DESCRIPTION
Inserted placeholder comments above select options for 'processType' and 'returningNegatives' fields in 120mm, 35mm, and disposable service forms to clarify intent and improve code readability.